### PR TITLE
Add stopАutoplay before relayoutChildren on window resize (responsive)

### DIFF
--- a/jquery.roundabout.js
+++ b/jquery.roundabout.js
@@ -170,6 +170,7 @@
 						// bind responsive action
 						if (settings.responsive) {
 							$(window).bind("resize", function() {
+								methods.stopAutoplay.apply(self);
 								methods.relayoutChildren.apply(self);
 							});
 						}


### PR DESCRIPTION
This fixes an issue that a ton of intervals are added, that end up
execution one over the other and break the autoplayDuration setting.
