### PR TITLE
check whether autoplay actually should be restarted after hover

### DIFF
--- a/jquery.roundabout.js
+++ b/jquery.roundabout.js
@@ -247,10 +247,14 @@
 					if (settings.autoplayPauseOnHover) {
 						self
 							.bind("mouseenter.roundabout.autoplay", function() {
-								methods.stopAutoplay.apply(self, [true]);
+								if(settings.autoplay && methods.isAutoplaying.apply(self)) {
+									methods.stopAutoplay.apply(self, [true]);
+								}
 							})
 							.bind("mouseleave.roundabout.autoplay", function() {
-								methods.startAutoplay.apply(self);
+								if(settings.autoplay && !methods.isAutoplaying.apply(self)) {
+									methods.startAutoplay.apply(self);
+								}
 							});
 					}
 


### PR DESCRIPTION
If you set `autoplayPauseOnHover` to `true` but `autoplay` to `false`, on initialization, you end up with a carousel that is initially paused, but that starts autoplaying as soon as user mouse moves over it and out again.

Here's a simple demo of the bug: http://jsfiddle.net/Aeon/AMtFn/1/ 

Open console and note that the carousel is initially paused, but once you mouse over it and mouse out, autoplay starts and `isAutoplaying` is now true.

Here's the demo after my fix: http://jsfiddle.net/Aeon/AMtFn/2/

Thanks for the great project, it's very nicely done!

PS. I wasn't sure what you use for minification, so I did not update the minified version of the code.
