### PR TITLE
Add ability to have a callback at the start of the clickToFocus animation

### DIFF
--- a/jquery.roundabout.js
+++ b/jquery.roundabout.js
@@ -77,6 +77,7 @@
 		btnStopAutoplay: null,
 		easing: "swing",
 		clickToFocus: true,
+		focusCallback: function() {},
 		clickToFocusCallback: function() {},
 		focusBearing: 0.0,
 		shape: "lazySusan",
@@ -188,6 +189,7 @@
 										if (!methods.isInFocus.apply(self, [degrees])) {
 											methods.stopAnimation.apply($(this));
 											if (!self.data("roundabout").animating) {
+												self.data("roundabout").focusCallback();
 												methods.animateBearingToFocus.apply(self, [degrees, self.data("roundabout").clickToFocusCallback]);
 											}
 											return false;


### PR DESCRIPTION
This may or may not be the best name (focusCallback) since it would be better to rename clickToFocusCallback too but this would be backwards incompatible for all the users out there. Instead, I've tried to give it a name which makes sense - feel free to rename (one or both of these). Also added a no-op default.
