### PR TITLE
retain autoplayPauseOnHover during btnStopAutoplay click and changeAutoplayDuration

### DIFF
--- a/jquery.roundabout.js
+++ b/jquery.roundabout.js
@@ -238,7 +238,7 @@
 					if (settings.btnStopAutoplay) {
 						$(settings.btnStopAutoplay)
 							.bind("click.roundabout", function() {
-								methods.stopAutoplay.apply(self);
+								methods.stopAutoplay.apply(self, [!!settings.autoplayPauseOnHover]);
 								return false;
 							});
 					}
@@ -1011,7 +1011,7 @@
 					data.autoplayDuration = duration;
 
 					if (methods.isAutoplaying.apply(self)) {
-						methods.stopAutoplay.apply(self);
+						methods.stopAutoplay.apply(self, [!!settings.autoplayPauseOnHover]);
 						setTimeout(function() {
 							methods.startAutoplay.apply(self);
 						}, 10);


### PR DESCRIPTION
We were losing the `autoplayPauseOnHover` behavior if a selector was supplied for `btnStopAutoplay` or if `changeAutoplayDuration` method was called.

This change should help retain those.
